### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A [Model Context Protocol](https://github.com/mcp-sdk/mcp) server implementation for [Replicate](https://replicate.com). This server provides access to Replicate's models and predictions through a simple tool-based interface.
 
+<a href="https://glama.ai/mcp/servers/q60hq1hwtr"><img width="380" height="200" src="https://glama.ai/mcp/servers/q60hq1hwtr/badge" alt="Replicate Server MCP server" /></a>
+
 ## Features
 
 ### Model Management


### PR DESCRIPTION
This PR adds a badge for the [Replicate MCP Server](https://glama.ai/mcp/servers/q60hq1hwtr) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/q60hq1hwtr"><img width="380" height="200" src="https://glama.ai/mcp/servers/q60hq1hwtr/badge" alt="Replicate Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.