### PR TITLE
Add create_and_poll_prediction tool for synchronous prediction result

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ npm install -g mcp-replicate
 ```
 
 2. Get your Replicate API token:
+
    - Go to [Replicate API tokens page](https://replicate.com/account/api-tokens)
    - Create a new token if you don't have one
    - Copy the token for the next step
@@ -59,17 +60,20 @@ npx mcp-replicate
 ## Features
 
 ### Models
+
 - Search models using semantic search
 - Browse models and collections
 - Get detailed model information and versions
 
 ### Predictions
+
 - Create predictions with text or structured input
 - Track prediction status
 - Cancel running predictions
 - List your recent predictions
 
 ### Image Handling
+
 - View generated images in your browser
 - Manage image cache for better performance
 
@@ -107,19 +111,23 @@ export REPLICATE_API_TOKEN=your_token_here
 ## Available Tools
 
 ### Model Tools
+
 - `search_models`: Find models using semantic search
 - `list_models`: Browse available models
 - `get_model`: Get details about a specific model
 - `list_collections`: Browse model collections
 - `get_collection`: Get details about a specific collection
 
-### Prediction Tools  
+### Prediction Tools
+
 - `create_prediction`: Run a model with your inputs
+- `create_and_poll_prediction`: Run a model with your inputs and wait until it's completed
 - `get_prediction`: Check a prediction's status
 - `cancel_prediction`: Stop a running prediction
 - `list_predictions`: See your recent predictions
 
 ### Image Tools
+
 - `view_image`: Open an image in your browser
 - `clear_image_cache`: Clean up cached images
 - `get_image_cache_stats`: Check cache usage
@@ -142,21 +150,25 @@ export REPLICATE_API_TOKEN=your_token_here
 ## Development
 
 1. Install dependencies:
+
 ```bash
 npm install
 ```
 
 2. Start development server (with auto-reload):
+
 ```bash
 npm run dev
 ```
 
 3. Check code style:
+
 ```bash
 npm run lint
 ```
 
 4. Format code:
+
 ```bash
 npm run format
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import {
   handleListCollections,
   handleGetCollection,
   handleCreatePrediction,
+  handleCreateAndPollPrediction,
   handleCancelPrediction,
   handleGetPrediction,
   handleListPredictions,
@@ -113,6 +114,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         input: request.params.arguments?.input as ModelIO,
         webhook: request.params.arguments?.webhook_url as string | undefined,
       });
+
+    case "create_and_poll_prediction":
+			return handleCreateAndPollPrediction(client, cache, {
+				version: request.params.arguments?.version as string | undefined,
+				model: request.params.arguments?.model as string | undefined,
+				input: request.params.arguments?.input as ModelIO,
+				webhook: request.params.arguments?.webhook_url as string | undefined,
+			});
 
     case "cancel_prediction":
       return handleCancelPrediction(client, cache, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,12 +116,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       });
 
     case "create_and_poll_prediction":
-			return handleCreateAndPollPrediction(client, cache, {
-				version: request.params.arguments?.version as string | undefined,
-				model: request.params.arguments?.model as string | undefined,
-				input: request.params.arguments?.input as ModelIO,
-				webhook: request.params.arguments?.webhook_url as string | undefined,
-			});
+      return handleCreateAndPollPrediction(client, cache, {
+        version: request.params.arguments?.version as string | undefined,
+        model: request.params.arguments?.model as string | undefined,
+        input: request.params.arguments?.input as ModelIO,
+        webhook: request.params.arguments?.webhook_url as string | undefined,
+      });
 
     case "cancel_prediction":
       return handleCancelPrediction(client, cache, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,6 +121,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         model: request.params.arguments?.model as string | undefined,
         input: request.params.arguments?.input as ModelIO,
         webhook: request.params.arguments?.webhook_url as string | undefined,
+        pollInterval: request.params.arguments?.poll_interval as
+          | number
+          | undefined,
+        timeout: request.params.arguments?.timeout as number | undefined,
       });
 
     case "cancel_prediction":

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -287,42 +287,20 @@ export async function handleCreateAndPollPrediction(
     model: string | undefined;
     input: ModelIO | string;
     webhook?: string;
+    pollInterval?: number;
+    timeout?: number;
   }
 ) {
-  try {
-    // If input is a string, wrap it in an object with 'prompt' property
-    const input =
-      typeof args.input === "string" ? { prompt: args.input } : args.input;
+  // If input is a string, wrap it in an object with 'prompt' property
+  const input =
+    typeof args.input === "string" ? { prompt: args.input } : args.input;
 
-    let prediction = await client.createPrediction({
+  let prediction;
+  try {
+    prediction = await client.createPrediction({
       ...args,
       input,
     });
-
-    // Cache the prediction and its initial status
-    cache.predictionCache.set(prediction.id, prediction);
-    cache.predictionStatus.set(
-      prediction.id,
-      prediction.status as PredictionStatus
-    );
-
-    do {
-      // Wait a second between polls
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      prediction = await client.getPredictionStatus(prediction.id);
-    } while (
-      prediction.status === "starting" ||
-      prediction.status === "processing"
-    );
-
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Created prediction ${prediction.id}, Output:${prediction.output}`,
-        },
-      ],
-    };
   } catch (error) {
     return {
       isError: true,
@@ -334,6 +312,83 @@ export async function handleCreateAndPollPrediction(
       ],
     };
   }
+
+  // Cache the prediction and its initial status
+  cache.predictionCache.set(prediction.id, prediction);
+  cache.predictionStatus.set(
+    prediction.id,
+    prediction.status as PredictionStatus
+  );
+
+  const shouldContinuePolling = (
+    prediction: Prediction | null,
+    timeoutAt: number
+  ) => {
+    if (!prediction) return true;
+    if (performance.now() > timeoutAt) return false;
+
+    if (
+      prediction.status === "succeeded" ||
+      prediction.status === "failed" ||
+      prediction.status === "canceled"
+    ) {
+      return false;
+    }
+    return true;
+  };
+
+  const { pollInterval = 1, timeout = 60 } = args;
+  const predictionId = prediction.id;
+  let timeoutAt = performance.now() + timeout * 1000;
+
+  do {
+    await new Promise((resolve) => setTimeout(resolve, pollInterval * 1000));
+
+    try {
+      prediction = await client.getPredictionStatus(predictionId);
+    } catch (error) {
+      console.error(error);
+    }
+  } while (shouldContinuePolling(prediction, timeoutAt));
+
+  if (timeoutAt < performance.now()) {
+    console.warn(
+      `Timeout reached while polling prediction by id: ${predictionId}`
+    );
+    return {
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: `Timeout reached while polling prediction by id: ${predictionId}`,
+        },
+      ],
+    };
+  }
+
+  if (prediction.status === "canceled" || prediction.status === "failed") {
+    console.warn(
+      `Prediction with id: ${predictionId} ${prediction.status} with error ${prediction.error}`
+    );
+    return {
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: `Prediction with id: ${predictionId} ${prediction.status} with error ${prediction.error}`,
+        },
+      ],
+    };
+  }
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: `Created prediction ${prediction.id}, Output: ${prediction.output}`,
+      },
+    ],
+  };
 }
 
 /**

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -16,6 +16,7 @@ import {
 } from "./models.js";
 import {
   createPredictionTool,
+  createAndPollPredictionTool,
   cancelPredictionTool,
   getPredictionTool,
   listPredictionsTool,
@@ -35,6 +36,7 @@ export const tools: Tool[] = [
   listCollectionsTool,
   getCollectionTool,
   createPredictionTool,
+  createAndPollPredictionTool,
   cancelPredictionTool,
   getPredictionTool,
   listPredictionsTool,

--- a/src/tools/predictions.ts
+++ b/src/tools/predictions.ts
@@ -42,6 +42,42 @@ export const createPredictionTool: Tool = {
 };
 
 /**
+ * Tool for creating a new prediction, waiting for it to complete,
+ * and returning the final output URL.
+ */
+export const createAndPollPredictionTool: Tool = {
+  name: "create_and_poll_prediction",
+  description:
+    "Create a new prediction and wait until it's completed. Accepts either a model version (for community models) or a model name (for official models), and returns the output URL after successful completion.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      version: {
+        type: "string",
+        description: "Model version ID to use (for community models)",
+      },
+      model: {
+        type: "string",
+        description: "Model name to use (for official models)",
+      },
+      input: {
+        type: "object",
+        description: "Input parameters for the model",
+        additionalProperties: true,
+      },
+      webhook_url: {
+        type: "string",
+        description: "Optional webhook URL for notifications",
+      },
+    },
+    oneOf: [
+      { required: ["version", "input"] },
+      { required: ["model", "input"] },
+    ],
+  },
+};
+
+/**
  * Tool for canceling predictions.
  */
 export const cancelPredictionTool: Tool = {

--- a/src/tools/predictions.ts
+++ b/src/tools/predictions.ts
@@ -48,7 +48,7 @@ export const createPredictionTool: Tool = {
 export const createAndPollPredictionTool: Tool = {
   name: "create_and_poll_prediction",
   description:
-    "Create a new prediction and wait until it's completed. Accepts either a model version (for community models) or a model name (for official models), and returns the output URL after successful completion.",
+    "Create a new prediction and wait until it's completed. Accepts either a model version (for community models) or a model name (for official models)",
   inputSchema: {
     type: "object",
     properties: {
@@ -68,6 +68,14 @@ export const createAndPollPredictionTool: Tool = {
       webhook_url: {
         type: "string",
         description: "Optional webhook URL for notifications",
+      },
+      poll_interval: {
+        type: "number",
+        description: "Optional interval between polls (default: 1)",
+      },
+      timeout: {
+        type: "number",
+        description: "Optional timeout for prediction (default: 60)",
       },
     },
     oneOf: [
@@ -133,4 +141,4 @@ export const listPredictionsTool: Tool = {
       },
     },
   },
-}; 
+};


### PR DESCRIPTION
When using create_prediction, users must manually poll the prediction endpoint until it’s marked as "succeeded" to access the output. This PR introduces a new tool that simplifies this process.

## What This PR Adds

This PR introduces a new tool: create_and_poll_prediction

This tool:
• Creates a prediction via Replicate	
• Automatically polls the prediction status until completion
• Returns the final output URL in a single response

```
{
  "tool": "create_and_poll_prediction",
  "arguments": {
    "model": "owner/model",
    "input": {
      "prompt": "Generate image"
    },
    "poll_interval": 2,
    "timeout": 90
  }
}
```

```
{
  "type": "text",
  "text": "Created prediction xyz123, Output: https://..."
}
```

## Technical Notes
•	Adds handleCreateAndPollPrediction in handlers.ts
•	Registers the tool and its input schema in tools/predictions.ts
•	Uses safe defaults (pollInterval = 1s, timeout = 60s)
•	Updates tool router in index.ts
•	Updates README to document the new tool
